### PR TITLE
Implement `InitializeToken` function to combine the request

### DIFF
--- a/contracts/BeiKeBox.sol
+++ b/contracts/BeiKeBox.sol
@@ -27,6 +27,12 @@ contract BeiKeBox is ERC1155 {
 
     event mintEvent(uint id);
 
+    function initializeToken(address producer, uint amount, uint price) public onlyOwner() returns (uint) {
+        uint id = mint(producer, amount);
+        setPrice(id, price);
+        return id;
+    }
+
     function mint(address producer, uint amount) public onlyOwner() returns (uint) {
         uint id = mint_id;
         _mint(producer, id, amount, "");

--- a/test/test_bkb_contract.js
+++ b/test/test_bkb_contract.js
@@ -3,6 +3,34 @@ const { assert } = require('chai');
 const truffleAssert = require('truffle-assertions');
 
 contract("BeiKeBox", (accounts) => {
+    describe("Initialize Token Test", async () => {
+        it("Initialize the token should emit the mintEvent", async () => {
+            const instance = await BeiKeBox.new()
+            let producer = accounts[1]
+            let id = 0
+            let amount = 32767
+            let price = 6;
+            
+            const transaction_recipt = await instance.initializeToken(producer, amount, price)
+            
+            const mint_id = Number.parseInt(transaction_recipt.logs[2].args.id).toString()
+            assert.equal(mint_id, id.toString(), "Incorrect ID")
+        });
+        it("Mulpitle initialize the token should emit the mintEvent with iterated ID", async () => {
+            const instance = await BeiKeBox.new()
+            let producer = accounts[1]
+            let id = 0
+            let next_id = id + 1
+            let amount = 32767
+            let price = 6;
+            await instance.initializeToken(producer, amount, price)
+            
+            const transaction_recipt = await instance.initializeToken(producer, amount, price)
+            
+            const mint_id = Number.parseInt(transaction_recipt.logs[2].args.id).toString()
+            assert.equal(mint_id, next_id.toString(), "Incorrect ID")
+        });
+    })
     describe("Mint Test", async () => {
         it("Mint token should have correct balance of token", async () => {
             const instance = await BeiKeBox.new()


### PR DESCRIPTION
## What's new?

In this PR, I implement `InitializeToken()` function to combine the `mint()` and `setPrice()` request: 

 - The `InitalizeToken()` function will call the `mint()` and `setPrice()` at the same time.
 - The `InitalizeToken()` will emit the `mintEvent()` with the ID attribute to get the token ID.
 - Implement the CI tests to test call the function only single time or call the function multiple times.